### PR TITLE
Nirpsec disperser fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,4 @@
+0.6 (Unreleased)
+
+- Fixed a bug in Nirspec "disperser" type reference files, where the
+  temperature coefficients were in the reverse order. [#1]

--- a/jwreftools/nirspec/nirspec_fs_ref_tools.py
+++ b/jwreftools/nirspec/nirspec_fs_ref_tools.py
@@ -336,8 +336,6 @@ def disperser2asdf(disfile, tiltyfile, tiltxfile, outname, ref_kw):
     fasdf : asdf.AsdfFile
 
     """
-
-    #t = {}
     disperser = disfile.split('.dis')[0].split('_')[1]
     with open(disfile) as f:
         lines=[l.strip() for l in f.readlines()]
@@ -375,7 +373,9 @@ def disperser2asdf(disfile, tiltyfile, tiltxfile, outname, ref_kw):
             l = line.split('\n')
             n = int(l[0].split()[1])
             coeffs = {}
-            for i , c in enumerate([float(c) for c in l[1:1+n]]):
+            idt_coef = [float(c) for c in l[1:1+n]]
+            #for i , c in enumerate([float(c) for c in l[1:1+n]]):
+            for i, c in enumerate(idt_coef[::-1]):
                 coeffs['c' + str(i)] = c
             tiltyd['tilt_model'] = models.Polynomial1D(n-1, **coeffs)
         elif line.startswith("Temperatures"):

--- a/jwreftools/nirspec/nirspec_fs_ref_tools.py
+++ b/jwreftools/nirspec/nirspec_fs_ref_tools.py
@@ -318,7 +318,7 @@ def disperser2asdf(disfile, tiltyfile, tiltxfile, outname, ref_kw):
     Create a NIRSPEC disperser reference file in ASDF format.
 
     Combine information stored in disperser_G?.dis and disperser_G?_TiltY.gtp
-    files delievred by the IDT.
+    files delivered by the IDT.
 
     disperser2asdf("disperser_G140H.dis", "disperser_G140H_TiltY.gtp", "disperserG140H.asdf")
 
@@ -374,7 +374,6 @@ def disperser2asdf(disfile, tiltyfile, tiltxfile, outname, ref_kw):
             n = int(l[0].split()[1])
             coeffs = {}
             idt_coef = [float(c) for c in l[1:1+n]]
-            #for i , c in enumerate([float(c) for c in l[1:1+n]]):
             for i, c in enumerate(idt_coef[::-1]):
                 coeffs['c' + str(i)] = c
             tiltyd['tilt_model'] = models.Polynomial1D(n-1, **coeffs)


### PR DESCRIPTION
Correct the temperature model for the GWA_X/YTILT correction.
The coefficients were recorded previously in the reverse order.

This fix requires all "disperser" type reference files to be recreated and delivered to CRDS .