### PR TITLE
V2V3 correction

### DIFF
--- a/jwreftools/miri/miri_imager_ref_tools.py
+++ b/jwreftools/miri/miri_imager_ref_tools.py
@@ -167,7 +167,7 @@ def create_miri_imager_distortion(distfile, outname):
     poly2t_mapping = models.Mapping([0, 1, 0, 1])
     poly2t_mapping.inverse = models.Mapping([0, 1, 0, 1])
 
-    distortion_transform = m_transform | mapping | poly | poly2t_mapping | t_transform | ident
+    distortion_transform = m_transform | mapping | poly | poly2t_mapping | t_transform | ident | models.Mapping([1,0])
 
     fdist.close()
     f = AsdfFile()
@@ -228,15 +228,15 @@ def test_transform(asdf_file):
 
     xy, v2, v3 values are from technical report with CDP-3 delivery
     """
-    v2 = np.array([-2, -2, -2, -2, -1.5, -1.5, -1.5, -1.5, -1, -1, -1, -1], dtype=np.float)
-    v3 = np.array([-8, -7.5, -7, -6.5, -8, -7.5, -7, -6.5, -8, -7.5, -7, -6.5], dtype=np.float)
+    v2 = np.array([-8, -7.5, -7, -6.5, -8, -7.5, -7, -6.5, -8, -7.5, -7, -6.5], dtype=np.float)
+    v3 = np.array([-2, -2, -2, -2, -1.5, -1.5, -1.5, -1.5, -1, -1, -1, -1], dtype=np.float)
     xy = np.array([[945.80, 728.45], [676.57, 748.63], [408.29, 768.69], [138.02, 789.09],
                    [924.30, 456.59],[655.18, 477.89], [387.05, 498.99], [116.92, 519.96],
                    [904.31, 185.02], [635.09, 207.37], [366.53, 229.45], [95.58, 250.95]],
                   dtype=np.float)
 
     f = AsdfFile.open(asdf_file)
-    transform = f.tree['distortion']
+    transform = f.tree['model']
     x, y = transform.inverse(v2, v3)
     assert_allclose(x, xy[:,0], atol=.05)
     assert_allclose(y, xy[:,1], atol=.05)


### PR DESCRIPTION
In discussion with @nden, there appeared to be an issue with the V2 / V3 data for the MIRI Imaging modes.  It appeared to just come down to the distortion file having the V2 and V3 reversed.

So, I added a `models.Mapping([1, 0])` at the end of the transform.  This is not a perfect fix as the row/col should be changed in the function but some initial attempts at that did not work.  The mapping did work and given time constraints this was deemed to be sufficient.

I had to also change the v2 and v3 arrays in the test function as they were reversed compared to the data on Page 5 in `MIRI-TN-00070-ATC_Imager_distortion_CDP_Issue_9.pdf`.

I added the mapping in there and ran the test function and they matched.

```
In [1]: from jwreftools.miri.miri_imager_ref_tools import create_miri_imager_distortion, test_transform, create_miri_imager_wcs_references

In [2]: create_miri_imager_wcs_references('MIRI_FM_MIRIMAGE_DISTORTION_06.03.00.fits', {'DISTORTION': 'jwst_miri_distortion_007c.asdf', 'FILTEROFFSET': 'jwst_miri_filter_offset_0007c.asdf'})

In [3]: test_transform('jwst_miri_distortion_007c.asdf')

In [4]:
```

and also did a sanity check in Python:
```
In [4]: from asdf import AsdfFile

In [5]: a = AsdfFile.open('jwst_miri_distortion_007c.asdf')

In [6]: a.tree['model'](945, 728)
Out[6]: (-7.993266078169735, -2.000859200389921)

In [7]: a.tree['model'].inverse(-8, -2)
Out[7]: (945.795147829476, 728.4501297039316)

In [8]:
```
and the output was close enough.