### PR TITLE
Updated tree entries to reflect changes required by redcat team

### DIFF
--- a/jwreftools/nircam/make_all_distortion_reffiles.py
+++ b/jwreftools/nircam/make_all_distortion_reffiles.py
@@ -1,0 +1,26 @@
+import nircam_reftools as ref
+from astropy.io import ascii
+import numpy as np
+
+siaf_file = 'NIRCam_SIAF-OSS_Summary_20161117_MMA.csv'
+
+siaf = ascii.read(siaf_file,data_start=18)
+siaf['col4'].fill_value = 'na'
+siaf['col18'].fill_value = 'na'
+siaf = siaf.filled()
+
+for entry in siaf:
+    apername = entry['col4']
+    opgs = str(entry['col18'])
+    if apername != 'na' and opgs != 'na' and 'GRISMR' not in apername and 'GRISMC' not in apername:
+        aper_minus_det = apername[6:]
+        det = apername[0:5]
+        try:
+            detnum = np.int(det[-1])
+            outname = 'reffiles_27Oct2016/' + det + '_' + aper_minus_det + '_distortion.asdf'
+            print('running {},{}'.format(apername,opgs))
+            ref.create_nircam_distortion('NIRCam_SIAF_2016-09-29.csv',det,aper_minus_det,opgs,outname)
+        except:
+            #print('skipping {}.'.format(entry))
+            pass
+        

--- a/jwreftools/nircam/nircam_reftools.py
+++ b/jwreftools/nircam/nircam_reftools.py
@@ -52,9 +52,9 @@ def create_nircam_distortion(detector, aperture, outname):
     """
     numdet = detector[-1]
     module = detector[-2]
-    channel = 'SW'
+    channel = 'SHORT'
     if numdet == '5':
-        channel = 'LW'
+        channel = 'LONG'
 
     full_aperture = detector + '_' + aperture
 
@@ -73,21 +73,33 @@ def create_nircam_distortion(detector, aperture, outname):
     model_inv =  Mapping([0, 1, 0, 1]) | v2v32idlx & v2v32idly | Mapping([0, 1, 0, 1]) | idl2scix & idl2sciy
     model.inverse = model_inv
 
-    tree = {"title": "NIRCAM Distortion",
-            "instrument": "NIRCAM",
-            "pedigree": "GROUND",
-            "reftype" : "DISTORTION",
-            "author": "B. Hilbert",
-            "detector": detector,
-            "module": module,
-            "channel": channel,
-            "subarray": aperture,
-            "description": "Distortion model function created from SIAF coefficients",
-            "exp_type": "NRC_IMAGE",
-            "useafter": "2014-01-01T00:00:00",
-            "model": model
+    #In the reference file headers, we need to switch NRCA5 to NRCALONG, and same
+    #for module B.
+    if detector[-1] == '5':
+        detector = detector[0:4] + 'LONG'
+
+    
+    tree = {"TITLE": "NIRCAM Distortion",
+            "TELESCOP": "JWST",
+            "INSTRUMENT": "NIRCAM",
+            "PEDIGREE": "GROUND",
+            "REFTYPE" : "DISTORTION",
+            "AUTHOR": "B. Hilbert",
+            "DETECTOR": detector,
+            "MODULE": module,
+            "CHANNEL": channel,
+            "SUBARRAY": aperture,
+            "DESCRIP": "Distortion model function created from SIAF coefficients",
+            "EXP_TYPE": "NRC_IMAGE",
+            "USEAFTER": "2014-01-01T00:00:00",
+            "model": model,
             }
 
     fasdf = AsdfFile()
     fasdf.tree = tree
+
+    sdict = {'name':'nircam_reftools.py','author':'B.Hilbert','homepage':'https://github.com/spacetelescope/jwreftools','version':'2.0'}
+
+    fasdf.add_history_entry("File created from a file of distortion coefficients, NIRCam_SIAF_2016-09-29.csv, provided by Colin Cox in October 2016. Software used: https://github.com/spacetelescope/jwreftools",software=sdict)
+        
     fasdf.write_to(outname)

--- a/jwreftools/nircam/nircam_reftools.py
+++ b/jwreftools/nircam/nircam_reftools.py
@@ -98,7 +98,7 @@ def create_nircam_distortion(detector, aperture, outname):
     fasdf = AsdfFile()
     fasdf.tree = tree
 
-    sdict = {'name':'nircam_reftools.py','author':'B.Hilbert','homepage':'https://github.com/spacetelescope/jwreftools','version':'2.0'}
+    sdict = {'name':'nircam_reftools.py','author':'B.Hilbert','homepage':'https://github.com/spacetelescope/jwreftools','version':'0.7'}
 
     fasdf.add_history_entry("File created from a file of distortion coefficients, NIRCam_SIAF_2016-09-29.csv, provided by Colin Cox in October 2016. Software used: https://github.com/spacetelescope/jwreftools",software=sdict)
         

--- a/jwreftools/nircam/nircam_reftools.py
+++ b/jwreftools/nircam/nircam_reftools.py
@@ -27,7 +27,7 @@ from astropy.modeling.models import Mapping
 
 import read_siaf_table
 
-def create_nircam_distortion(detector, aperture, outname):
+def create_nircam_distortion(coefffile, detector, aperture, opgsname, outname):
     """
     Create an asdf reference file with all distortion components for the NIRCam imager.
 
@@ -40,7 +40,6 @@ def create_nircam_distortion(detector, aperture, outname):
     ----------
     detector : str
         NRCB1, NRCB2, NRCB3, NRCB4, NRCB5, NRCA1, NRCA2, NRCA3, NRCA4, NRCA5
-        (NRCA5 and NRCB5 are the LW detectors) 
     aperture : str
         Name of the aperture/subarray. (e.g. FULL, SUB160, SUB320, SUB640, GRISM_F322W2)
     outname : str
@@ -55,17 +54,16 @@ def create_nircam_distortion(detector, aperture, outname):
     channel = 'SHORT'
     if numdet == '5':
         channel = 'LONG'
-
+        
     full_aperture = detector + '_' + aperture
 
-
     #"Forward' transformations. science --> ideal --> V2V3
-    sci2idlx, sci2idly, sciunit, idlunit = read_siaf_table.get_siaf_transform(full_aperture,'science','ideal', 5)
-    idl2v2v3x, idl2v2v3y = read_siaf_table.get_siaf_v2v3_transform(full_aperture,from_system='ideal')
+    sci2idlx, sci2idly, sciunit, idlunit = read_siaf_table.get_siaf_transform(coefffile,full_aperture,'science','ideal', 5)
+    idl2v2v3x, idl2v2v3y = read_siaf_table.get_siaf_v2v3_transform(coefffile,full_aperture,from_system='ideal')
 
     #'Reverse' transformations. V2V3 --> ideal --> science
-    v2v32idlx, v2v32idly = read_siaf_table.get_siaf_v2v3_transform(full_aperture,to_system='ideal')
-    idl2scix, idl2sciy, idlunit, sciunit = read_siaf_table.get_siaf_transform(full_aperture,'ideal','science', 5)
+    v2v32idlx, v2v32idly = read_siaf_table.get_siaf_v2v3_transform(coefffile,full_aperture,to_system='ideal')
+    idl2scix, idl2sciy, idlunit, sciunit = read_siaf_table.get_siaf_transform(coefffile,full_aperture,'ideal','science', 5)
     
  
     #Map the models together to make a single transformation
@@ -73,12 +71,13 @@ def create_nircam_distortion(detector, aperture, outname):
     model_inv =  Mapping([0, 1, 0, 1]) | v2v32idlx & v2v32idly | Mapping([0, 1, 0, 1]) | idl2scix & idl2sciy
     model.inverse = model_inv
 
+
     #In the reference file headers, we need to switch NRCA5 to NRCALONG, and same
     #for module B.
     if detector[-1] == '5':
         detector = detector[0:4] + 'LONG'
-
     
+
     tree = {"TITLE": "NIRCAM Distortion",
             "TELESCOP": "JWST",
             "INSTRUMENT": "NIRCAM",
@@ -88,18 +87,18 @@ def create_nircam_distortion(detector, aperture, outname):
             "DETECTOR": detector,
             "MODULE": module,
             "CHANNEL": channel,
-            "SUBARRAY": aperture,
+            "SUBARRAY": opgsname,
             "DESCRIP": "Distortion model function created from SIAF coefficients",
             "EXP_TYPE": "NRC_IMAGE",
             "USEAFTER": "2014-01-01T00:00:00",
-            "model": model,
+            "model": model
             }
 
     fasdf = AsdfFile()
     fasdf.tree = tree
 
     sdict = {'name':'nircam_reftools.py','author':'B.Hilbert','homepage':'https://github.com/spacetelescope/jwreftools','version':'0.7'}
-
+    
     fasdf.add_history_entry("File created from a file of distortion coefficients, NIRCam_SIAF_2016-09-29.csv, provided by Colin Cox in October 2016. Software used: https://github.com/spacetelescope/jwreftools",software=sdict)
-        
+
     fasdf.write_to(outname)

--- a/jwreftools/nircam/read_siaf_table.py
+++ b/jwreftools/nircam/read_siaf_table.py
@@ -156,7 +156,7 @@ def get_siaf_v2v3_transform(aperture,from_system='v2v3',to_system='v2v3'):
 
     #Then create the model for the transformation
     parity = row['VIdlParity'].data[0]
-    v3_ideal_y_angle = row['V3IdlYAngle'].data[0]
+    v3_ideal_y_angle = row['V3IdlYAngle'].data[0] * np.pi / 180.
     
     X_model, Y_model = v2v3_model(from_system,to_system,parity,v3_ideal_y_angle)
 

--- a/jwreftools/nircam/read_siaf_table.py
+++ b/jwreftools/nircam/read_siaf_table.py
@@ -3,7 +3,7 @@ from astropy.io import ascii
 from astropy.modeling import models
 import sys
 
-t = ascii.read("NIRCam_SIAF_2016-09-29.csv",header_start=1)
+#t = ascii.read("NIRCam_SIAF_2016-09-29.csv",header_start=1)
 
 """
 Based on SIAF transforms PATHS
@@ -16,7 +16,7 @@ V2,V3 --> ideal --> science
 
 """
 
-def get_siaf_transform(aperture, from_system, to_system, degree):
+def get_siaf_transform(coefffile, aperture, from_system, to_system, degree):
     """
     This reads in the file with transformations that the TEL team
     is using to construct the SIAF file. These transformations are
@@ -52,6 +52,9 @@ def get_siaf_transform(aperture, from_system, to_system, degree):
     >>> get_siaf_transform('NRCA1_FULL', "science", "ideal", 5)
 
     """
+    #read in csv file of coefficients
+    #t = ascii.read("NIRCam_SIAF_2016-09-29.csv",header_start=1)
+    t = ascii.read(coefffile,header_start=1)
 
     #from_system and to_system are very limited. Can only be "ideal" for the 
     #distortion-free coords, and "science" for distorted coords
@@ -134,11 +137,15 @@ def to_model(coeffs, degree=5):
 
 
 
-def get_siaf_v2v3_transform(aperture,from_system='v2v3',to_system='v2v3'):
+def get_siaf_v2v3_transform(coefffile,aperture,from_system='v2v3',to_system='v2v3'):
     """
     Generate transformation model to go to/from V2/V3 from 
     undistorted angular distnaces from the reference pixel ("ideal")
     """
+    #read in csv file of coefficients
+    #t = ascii.read("NIRCam_SIAF_2016-09-29.csv",header_start=1)
+    t = ascii.read(coefffile,header_start=1)
+
     from_system = from_system.lower()
     to_system = to_system.lower()
 
@@ -158,6 +165,8 @@ def get_siaf_v2v3_transform(aperture,from_system='v2v3',to_system='v2v3'):
     parity = row['VIdlParity'].data[0]
     v3_ideal_y_angle = row['V3IdlYAngle'].data[0] * np.pi / 180.
     
+    #print("parity and angle are {}, {}".format(parity,v3_ideal_y_angle))
+
     X_model, Y_model = v2v3_model(from_system,to_system,parity,v3_ideal_y_angle)
 
     return X_model, Y_model
@@ -191,6 +200,12 @@ def v2v3_model(from_sys, to_sys, par, angle):
     xc['c0_0'] = 0
     yc['c0_0'] = 0
     
+
+    #print("coeffs for v2v3 transform:")
+    #for key in xc:
+    #    print("{} {}".format(key,xc[key]))
+    #sys.exit()
+
     xmodel = models.Polynomial2D(1, **xc)
     ymodel = models.Polynomial2D(1, **yc)
 


### PR DESCRIPTION
Redcat team requires longwave detector names to be (e.g.) NRCALONG rather than NRCA5. Also added required HISTORY keyword. The HH:MM:SS part of the useafter string is also now required, whereas it used to be optional.