### PR TITLE
Add data member to extract specific orders for WFSS reference file

### DIFF
--- a/jwreftools/nircam/nircam_grism_reffiles.py
+++ b/jwreftools/nircam/nircam_grism_reffiles.py
@@ -250,7 +250,7 @@ def create_grism_config(conffile="",
     ref.validate()
 
 
-def create_grism_waverange(outname="",
+def create_grism_wavelengthrange(outname="",
                            history="Ground NIRCAM Grismwavelengthrange",
                            author="STScI",
                            filter_range=None,
@@ -311,14 +311,14 @@ def create_grism_waverange(outname="",
                 extract_orders.append(orders)
 
     # filters for every order
-    wrange_selector = list(filter_range[orders[0]].keys())
+    waverange_selector = list(filter_range[orders[0]].keys())
 
     # The lists below need
     # to remain ordered to be correctly referenced
     wavelengthrange = []
     for order in orders:
         o = []
-        for fname in wrange_selector:
+        for fname in waverange_selector:
             o.append(filter_range[order][fname])
         wavelengthrange.append(o)
 
@@ -327,8 +327,8 @@ def create_grism_waverange(outname="",
     ref.meta.exposure.p_exptype = "NRC_GRISM|NRC_TSGRISM"
     ref.meta.input_units = u.micron
     ref.meta.output_units = u.micron
-    ref.wrange_selector = wrange_selector
-    ref.wrange = wavelengthrange
+    ref.waverange_selector = waverange_selector
+    ref.wavelengthrange = wavelengthrange
     ref.extract_orders = extract_orders
     ref.order = orders
 

--- a/jwreftools/nircam/nircam_grism_reffiles.py
+++ b/jwreftools/nircam/nircam_grism_reffiles.py
@@ -51,15 +51,15 @@ def common_reference_file_keywords(reftype=None,
     return ref_file_common_keywords
 
 
-def create_grism_config(conffile="",
-                        pupil=None,
-                        module=None,
-                        author="STScI",
-                        history="",
-                        outname=None):
+def create_grism_specwcs(conffile="",
+                         pupil=None,
+                         module=None,
+                         author="STScI",
+                         history="",
+                         outname=None):
     """
     Create an asdf reference file to hold Grism C (column) or Grism R (rows)
-    configuration, no sensativity information is included
+    configuration information, no sensativity information is included
 
     Note: The orders are named alphabetically, i.e. Order A, Order B
     There are also sensativity fits files which are tables of wavelength,
@@ -111,7 +111,7 @@ def create_grism_config(conffile="",
 
     """
     if outname is None:
-        outname = "nircam_wfss_wavelengthrange.asdf"
+        outname = "nircam_wfss_specwcs.asdf"
     if not history:
         history = "Created from {0:s}".format(conffile)
 

--- a/jwreftools/nircam/nircam_grism_reffiles.py
+++ b/jwreftools/nircam/nircam_grism_reffiles.py
@@ -279,7 +279,8 @@ def create_grism_config(conffile="",
 def create_grism_waverange(outname="",
                            history="Ground NIRCAM Grismwavelengthrange",
                            author="STScI",
-                           filter_range=None):
+                           filter_range=None,
+                           extract_orders=None):
     """Create a wavelengthrange reference file.
 
     Supply a filter range dictionary keyed on order or use the default
@@ -323,11 +324,19 @@ def create_grism_waverange(outname="",
 
     # array of integers
     orders = list(filter_range.keys())
-    orders.sort()
+
+
+    if extract_orders is None:
+        # Nircam has not specified any limitation on the orders
+        # that should be extracted by default yet so all are
+        # included. 
+        extract_orders = []
+        for order in filter_range.keys():
+            for filter in filter_range[order].keys(): 
+                extract_orders.append(orders)
 
     # same filters for every order, array of strings
     wrange_selector = list(filter_range[orders[0]].keys())
-    wrange_selector.sort()
 
     # The lists below need
     # to remain ordered to be correctly referenced
@@ -345,6 +354,7 @@ def create_grism_waverange(outname="",
     ref.meta.output_units = u.micron
     ref.wrange_selector = wrange_selector
     ref.wrange = wavelengthrange
+    ref.extract_orders = extract_orders
     ref.order = orders
 
     entry = HistoryEntry({'description': history, 'time': datetime.datetime.utcnow()})

--- a/jwreftools/nircam/nircam_grism_reffiles.py
+++ b/jwreftools/nircam/nircam_grism_reffiles.py
@@ -250,7 +250,7 @@ def create_grism_config(conffile="",
     ref.validate()
 
 
-def create_grism_wavelengthrange(outname="nircam_grism_wavelengthrange.asdf",
+def create_grism_wavelengthrange(outname="nircam_wavelengthrange.asdf",
                                  history="Ground NIRCAM Grism wavelengthrange",
                                  author="STScI",
                                  wavelengthrange=None,
@@ -277,6 +277,7 @@ def create_grism_wavelengthrange(outname="nircam_grism_wavelengthrange.asdf",
                                             description="NIRCAM Grism-Filter Wavelength Ranges",
                                             exp_type="NRC_WFSS",
                                             author=author,
+                                            pupil="ANY",
                                             model_type="WavelengthrangeModel",
                                             filename=outname,
                                             )

--- a/jwreftools/nircam/nircam_grism_reffiles.py
+++ b/jwreftools/nircam/nircam_grism_reffiles.py
@@ -250,11 +250,92 @@ def create_grism_config(conffile="",
     ref.validate()
 
 
-def create_grism_wavelengthrange(outname="nircam_wavelengthrange.asdf",
-                                 history="Ground NIRCAM Grism wavelengthrange",
-                                 author="STScI",
-                                 wavelengthrange=None,
-                                 extract_orders=None):
+def create_tsgrism_wavelengthrange(outname="nircam_tsgrism_wavelengthrange.asdf",
+                                   history="Ground NIRCAM TSGrism wavelengthrange",
+                                   author="STScI",
+                                   wavelengthrange=None,
+                                   extract_orders=None):
+    """Create a wavelengthrange reference file for NIRCAM TSGRISM mode.
+
+    Parameters
+    ----------
+    outname: str
+        The output name of the file
+    history: str
+        History information about it's creation
+    author: str
+        Person or entity making the file
+    wavelengthrange: list(tuples)
+        A list of tuples that set the order, filter, and
+        wavelength range min and max
+    extract_orders: list[list]
+        A list of lists that specify
+
+    """
+    ref_kw = common_reference_file_keywords(reftype="wavelengthrange",
+                                            title="NIRCAM TSGRISM reference file",
+                                            description="NIRCAM Grism-Filter Wavelength Ranges",
+                                            exp_type="NRC_TSGRISM",
+                                            author=author,
+                                            pupil="ANY",
+                                            model_type="WavelengthrangeModel",
+                                            filename=outname,
+                                            )
+
+    if wavelengthrange is None:
+        # This is a list of tuples that specify the
+        # order, filter, wave min, wave max
+        wavelengthrange = [(1, 'F277W', 2.500411072, 3.807062006),
+                           (1, 'F322W2', 2.5011293930000003, 4.215842089),
+                           (1, 'F356W', 3.001085025, 4.302320901),
+                           (1, 'F444W', 3.696969216, 4.899565197),
+                           (2, 'F277W', 2.500411072, 3.2642254050000004),
+                           (2, 'F322W2', 2.5011293930000003, 4.136119434),
+                           (2, 'F356W', 2.529505253, 4.133416971),
+                           (2, 'F444W', 2.5011293930000003, 4.899565197),
+                           ]
+
+    # array of integers of unique orders
+    orders = sorted(set((x[0] for x in wavelengthrange)))
+    filters = sorted(set((x[1] for x in wavelengthrange)))
+
+    # Nircam has not specified any limitation on the orders
+    # that should be extracted by default yet so all are
+    # included.
+    if extract_orders is None:
+        extract_orders = [('F277W', [1]),
+                          ('F322W2', [1]),
+                          ('F356W', [1]),
+                          ('F444W', [1]),
+                          ]
+
+    ref = wcs_ref_models.WavelengthrangeModel()
+    ref.meta.update(ref_kw)
+    ref.meta.exposure.p_exptype = "NRC_TSGRISM"
+    ref.meta.input_units = u.micron
+    ref.meta.output_units = u.micron
+    ref.wavelengthrange = wavelengthrange
+    ref.extract_orders = extract_orders
+    ref.order = orders
+    ref.waverange_selector = filters
+
+    history = HistoryEntry({'description': history,
+                            'time': datetime.datetime.utcnow()})
+    software = Software({'name': 'nircam_reftools.py',
+                         'author': author,
+                         'homepage': 'https://github.com/spacetelescope/jwreftools',
+                         'version': '0.7.1'})
+    history['software'] = software
+    ref.history = [history]
+    ref.validate()
+    ref.to_asdf(outname)
+
+
+def create_wfss_wavelengthrange(outname="nircam_wfss_wavelengthrange.asdf",
+                                history="Ground NIRCAM Grism wavelengthrange",
+                                author="STScI",
+                                wavelengthrange=None,
+                                extract_orders=None):
     """Create a wavelengthrange reference file for NIRCAM.
 
     Parameters
@@ -273,7 +354,7 @@ def create_grism_wavelengthrange(outname="nircam_wavelengthrange.asdf",
 
     """
     ref_kw = common_reference_file_keywords(reftype="wavelengthrange",
-                                            title="NIRCAM Grism wavelenghtrange",
+                                            title="NIRCAM WFSS reference file",
                                             description="NIRCAM Grism-Filter Wavelength Ranges",
                                             exp_type="NRC_WFSS",
                                             author=author,
@@ -312,7 +393,6 @@ def create_grism_wavelengthrange(outname="nircam_wavelengthrange.asdf",
                            ]
     # array of integers of unique orders
     orders = sorted(set((x[0] for x in wavelengthrange)))
-
     filters = sorted(set((x[1] for x in wavelengthrange)))
 
     # Nircam has not specified any limitation on the orders
@@ -325,7 +405,7 @@ def create_grism_wavelengthrange(outname="nircam_wavelengthrange.asdf",
 
     ref = wcs_ref_models.WavelengthrangeModel()
     ref.meta.update(ref_kw)
-    ref.meta.exposure.p_exptype = "NRC_WFSS|NRC_TSGRISM"
+    ref.meta.exposure.p_exptype = "NRC_WFSS"
     ref.meta.input_units = u.micron
     ref.meta.output_units = u.micron
     ref.wavelengthrange = wavelengthrange
@@ -341,11 +421,8 @@ def create_grism_wavelengthrange(outname="nircam_wavelengthrange.asdf",
                          'version': '0.7.1'})
     history['software'] = software
     ref.history = [history]
-    ref.to_asdf(outname)
     ref.validate()
-
     ref.to_asdf(outname)
-    ref.validate()
 
 
 def split_order_info(keydict):

--- a/jwreftools/niriss/niriss_grism_reffiles.py
+++ b/jwreftools/niriss/niriss_grism_reffiles.py
@@ -104,7 +104,7 @@ def common_reference_file_keywords(reftype=None,
 
 def create_grism_config(conffile="",
                         fname="",
-                        pupil="",
+                        pupil=None,
                         author="STScI",
                         history="NIRISS Grism Parameters",
                         outname=""):
@@ -163,7 +163,7 @@ def create_grism_config(conffile="",
 
     if not fname:
         fname = conffile.split(".")[0]
-    if not pupil:
+    if pupil is None:
         pupil = conffile.split(".")[1]
 
     ref_kw = common_reference_file_keywords(reftype="specwcs",
@@ -301,6 +301,8 @@ def create_grism_wavelengthrange(outname="niriss_wavelengthrange.asdf",
         History information about it's creation
     author: str
         Person or entity making the file
+    module: str
+    pupil: str
     wavelengthrange: list(tuples)
         A list of tuples that set the order, filter, and wavelength
         range min and max

--- a/jwreftools/niriss/niriss_grism_reffiles.py
+++ b/jwreftools/niriss/niriss_grism_reffiles.py
@@ -290,7 +290,8 @@ def create_grism_waverange(outname="",
                            author="STScI",
                            module="N/A",
                            pupil="N/A",
-                           filter_range=None):
+                           filter_range=None,
+                           extract_orders=None):
     """Create a wavelengthrange reference file. There is a different file for each filter
 
     Supply a filter range dictionary or use the default
@@ -325,12 +326,26 @@ def create_grism_waverange(outname="",
         orders = [-1, 0, 1, 2, 3]
     else:
         # array of integers
-        orders = list(filter_range.keys())
+        orders = list(np.arange(len(filter_range.keys())))
         orders.sort()
+
+    if extract_orders is None:
+        # These are the orders that will be extracted by
+        # default in the pipeline. It should be a list
+        # of list ordered the same as filter_range 
+        # that says what orders
+        # should be extracted for each filter.
+        # The values that are currently here are those
+        # specified by Kevin Volk via communication.
+        extract_orders = [[1, 2],
+                          [1],
+                          [1],
+                          [1],
+                          [1],
+                          [1]]
 
     # same filters for every order, array of strings
     wrange_selector = list(filter_range.keys())
-    wrange_selector.sort()
 
     # The lists below need
     # to remain ordered to be correctly referenced
@@ -348,6 +363,7 @@ def create_grism_waverange(outname="",
     ref.wrange_selector = wrange_selector
     ref.wrange = wavelengthrange
     ref.order = orders
+    ref.extract_orders = extract_orders
     entry = HistoryEntry({'description': history, 'time': datetime.datetime.utcnow()})
     sdict = Software({'name': 'niriss_reftools.py',
                       'author': author,

--- a/jwreftools/niriss/niriss_grism_reffiles.py
+++ b/jwreftools/niriss/niriss_grism_reffiles.py
@@ -289,7 +289,7 @@ def create_grism_config(conffile="",
     ref.validate()
 
 
-def create_grism_waverange(outname="",
+def create_grism_wavelengthrange(outname="",
                            history="NIRCAM Grism wavelengthrange",
                            author="STScI",
                            module="N/A",
@@ -302,7 +302,7 @@ def create_grism_waverange(outname="",
 
     """
     ref_kw = common_reference_file_keywords(reftype="wavelengthrange",
-                                            title="NIRISS WFSS waverange",
+                                            title="NIRISS WFSS wavelengthrange",
                                             exp_type="NIS_WFSS",
                                             description="NIRISS WFSS Filter Wavelength Ranges",
                                             useafter="2014-01-01T00:00:00",
@@ -351,14 +351,14 @@ def create_grism_waverange(outname="",
                           [1]]
 
     # same filters for every order, array of strings
-    wrange_selector = list(filter_range.keys())
+    waverange_selector = list(filter_range.keys())
 
     # The lists below need
     # to remain ordered to be correctly referenced
     wavelengthrange = []
     for order in orders:
         o = []
-        for fname in wrange_selector:
+        for fname in waverange_selector:
             o.append(filter_range[fname])
         wavelengthrange.append(o)
 
@@ -366,8 +366,8 @@ def create_grism_waverange(outname="",
     ref.meta.update(ref_kw)
     ref.meta.input_units = u.micron
     ref.meta.output_units = u.micron
-    ref.wrange_selector = wrange_selector
-    ref.wrange = wavelengthrange
+    ref.waverange_selector = waverange_selector
+    ref.wavelengthrange = wavelengthrange
     ref.order = orders
     ref.extract_orders = extract_orders
 


### PR DESCRIPTION
This adds the member `extract_orders` to the nircam and niriss `wavelengthrange` reference files so that only specific orders, per filter, will be extracted.  This will serve as the default for pipeline use, but the orders to be extracted can be specifified in direct calls to `extract_2d`.

see also: https://github.com/STScI-JWST/jwst/pull/1801