### PR TITLE
ote transform with unit conversion

### DIFF
--- a/jwreftools/nirspec/ote2asdf.py
+++ b/jwreftools/nirspec/ote2asdf.py
@@ -53,7 +53,7 @@ def ote2asdf(otepcf, author, description, useafter):
     input2poly_mapping.inverse = Identity(2)
 
     # The Nirspec model returns values in degrees.
-    # We are converting them to arcsec in order to use the same V@V# to sky
+    # We are converting them to arcsec in order to use the same V2V3 to sky
     # transform as other instruments.
     unit_transform = models.Scale(3600) & models.Scale(3600)
 

--- a/jwreftools/nirspec/ote2asdf.py
+++ b/jwreftools/nirspec/ote2asdf.py
@@ -52,7 +52,12 @@ def ote2asdf(otepcf, author, description, useafter):
     input2poly_mapping = Mapping([0, 1, 0, 1], name='ote_inmap')
     input2poly_mapping.inverse = Identity(2)
 
-    model_poly = input2poly_mapping | (x_poly_forward & y_poly_forward) | output2poly_mapping
+    # The Nirspec model returns values in degrees.
+    # We are converting them to arcsec in order to use the same V@V# to sky
+    # transform as other instruments.
+    unit_transform = models.Scale(3600) & models.Scale(3600)
+
+    model_poly = input2poly_mapping | (x_poly_forward & y_poly_forward) | output2poly_mapping | unit_transform
 
     model = model_poly | mlinear
     ote_model = OTEModel()

--- a/jwreftools/nirspec/ote2asdf.py
+++ b/jwreftools/nirspec/ote2asdf.py
@@ -20,7 +20,8 @@ def ote2asdf(otepcf, author, description, useafter):
     input_rot_center = lines[lines.index('*InputRotationCentre 2 1') + 1].split()
     output_rot_center = lines[lines.index('*OutputRotationCentre 2 1') + 1].split()
 
-    mlinear = homothetic_det2sky(input_rot_center, rotation_angle, factors, output_rot_center, name="ote")
+    mlinear = homothetic_det2sky(input_rot_center, rotation_angle,
+                                 factors, output_rot_center, name="ote")
 
     degree = int(lines[lines.index('*FitOrder') + 1])
 
@@ -57,15 +58,16 @@ def ote2asdf(otepcf, author, description, useafter):
     # transform as other instruments.
     unit_transform = models.Scale(3600) & models.Scale(3600)
 
-    model_poly = input2poly_mapping | (x_poly_forward & y_poly_forward) | output2poly_mapping | unit_transform
+    model_poly = input2poly_mapping | (x_poly_forward & y_poly_forward) | output2poly_mapping
 
-    model = model_poly | mlinear
+    model = model_poly | mlinear | unit_transform
     ote_model = OTEModel()
     ote_model.model = model
     ote_model.meta.author = author
     ote_model.meta.description = description
     ote_model.meta.useafter = useafter
     ote_model.meta.pedigree = "GROUND"
+    ote_model.meta.output_units = 'arcsec'
     return ote_model
 
 


### PR DESCRIPTION
This appends a unit conversion to the end of the OTE transform so that the units in V2V3 are arcsec.
Fix #23.

JIRA ticket:  CRDS-201
@cherylpavlovski @jmuzerolle