### PR TITLE
Add script for reformatting NIRSpec flat-field reference files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,4 +3,4 @@
 - Fixed a bug in Nirspec "disperser" type reference files, where the
   temperature coefficients were in the reverse order. [#1]
 
-- Added module reformat_nrs_ff. [#wxyz]
+- Added module reformat_nrs_ff. [#35]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,3 +2,5 @@
 
 - Fixed a bug in Nirspec "disperser" type reference files, where the
   temperature coefficients were in the reverse order. [#1]
+
+- Added module reformat_nrs_ff. [#wxyz]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,15 @@
+.. jwreftools documentation master file
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+:ref:`genindex`  |  :ref:`modindex`
+
+
+=====================
+Package Documentation
+=====================
+
+.. toctree::
+   :maxdepth: 1
+
+   jwreftools/package_index.rst

--- a/docs/jwreftools/package_index.rst
+++ b/docs/jwreftools/package_index.rst
@@ -1,0 +1,7 @@
+=============
+Package Index
+=============
+.. toctree::
+   :maxdepth: 2
+
+   reformat_nrs_ff/index.rst

--- a/docs/jwreftools/reformat_nrs_ff/arguments.rst
+++ b/docs/jwreftools/reformat_nrs_ff/arguments.rst
@@ -1,0 +1,41 @@
+Arguments
+=========
+There is one user-callable function in the `reformat_nrs_ff` module,
+`process_files`.  The script may be run by importing reformat_nrs_ff
+in Python, then executing reformat_nrs_ff.process_files().  The files
+to be converted have (previously, at least) been provided in several
+directories, so it was intended that this script be run once for each
+of these directories, using a wildcard to select all FITS files in
+each directory.  The output may be written to the default directory.
+For example::
+
+    import reformat_nrs_ff
+    reformat_nrs_ff.process_files("directory1/*fits", prefix="v2_")
+    reformat_nrs_ff.process_files("directory2/*fits", prefix="v2_")
+    reformat_nrs_ff.process_files("directory3/*fits", prefix="v2_")
+
+process_files
+-------------
+This function will read and convert the specified FITS files.
+
+*  ``pattern``
+
+``pattern`` is a string, the full path name to one or more NIRSpec
+flat-field files in FITS format.  Wildcards may be used.  These files
+will be copied and reformatted; the input files themselves will not be
+modified.  See also `prefix`.
+
+* ``prefix``
+
+For each input file name, the output file name will be constructed by
+taking the basename of the input file name, and then appending the
+basename to `prefix`.  Note that unless `prefix` includes a directory
+name, the output file or files will be written to the default directory.
+If `prefix` does include a directory name, that directory must already
+exist.  The input and output names may be the same if prefix="" and the
+input name includes a directory that is different from the default
+directory.
+
+* ``verbose``
+
+If True, information will be printed to the standard output.

--- a/docs/jwreftools/reformat_nrs_ff/description.rst
+++ b/docs/jwreftools/reformat_nrs_ff/description.rst
@@ -1,0 +1,54 @@
+Description
+===========
+This module converts NIRSpec flat-field reference files from the IDT's
+format to the format that can be submitted to CRDS for use by the
+jwst/flat_field step.
+
+Here is a summary of the differences to be expected between the input
+and output files.
+
+In the fore optics flats for MSA data, the extension names include "_Q1",
+"_Q2", "_Q3", or "_Q4" (e.g. SCI_Q1), depending on the quadrant.  The
+reformatted file will use EXTNAME = "SCI" (for example), together with
+EXTVER = 1, 2, 3, or 4 to identify the quadrant.
+
+The tables for "fast" variation of the flat field with wavelength have
+extension names RQE, IFU, or VECTOR.  One of these tables has column name
+"RQE" for the flat-field data, while all other such tables have column name
+"DATA".  In the output files, the extension name for this table will be
+"FAST_VARIATION", and the column name for flat-field data will be "DATA".
+In some of the fast-variation tables, the wavelength and data values are 0;
+in this case, wavelength and data will be changed to 1.
+
+For fixed-slit data, separate extensions are used for the fast variation
+tables, with EXTNAME set to the slit name (but not the slit names used by
+DMS).  The output file will have one fast-variation table with with
+multiple rows, with column names "wavelength" and "data" (the latter is
+for the flat-field values), and with the DMS slit name in a column with
+name "slit_name".
+
+The DQ_DEF extensions have column names "BIT", "VAL", "NAME", and
+"DESCRIPTION".  "VAL" will be renamed to "VALUE".  The string lengths for
+NAME and DESCRIPTION will be assigned new values.
+
+For SCI extensions that have a 3-D data array, each plane corresponds to
+a different wavelength.  The wavelength value for each plane was written
+to a keyword in the SCI extension header.  In some files the keywords
+started with "FLAT", and in other files the keywords started with "PFLAT".
+Following "FLAT" or "PFLAT", there was an integer index that started
+with 0 in some files and 1 in other files.  In the output files, the
+wavelengths will be stored in a new table extension with a single column,
+"WAVELENGTH".
+
+The flat field image data (i.e. not the tables) are in detector
+orientation.  These will be changed to DMS (sky) orientation in the output.
+
+In some files, the DQ image extension has data type float; this will be
+cast to int32 for the output file.
+
+Some required primary header keywords will be added, renamed, or modified.
+INSTRUME was occasionally written INSRTUME.  USEAFTER needs to include the
+time (even if it's 0), and the value was in some cases not a date at all.
+EXP_TYPE will be added.  REFTYPE will be changed to FFLAT, SFLAT, or DFLAT.
+If FILTER is OPAQUE, it will be changed to the value that would be expected
+for a science exposure.

--- a/docs/jwreftools/reformat_nrs_ff/index.rst
+++ b/docs/jwreftools/reformat_nrs_ff/index.rst
@@ -1,0 +1,10 @@
+===============
+reformat_nrs_ff
+===============
+.. toctree::
+   :maxdepth: 2
+
+   description.rst
+   arguments.rst
+
+.. automodapi:: jwreftools.reformat_nrs_ff

--- a/jwreftools/__init__.py
+++ b/jwreftools/__init__.py
@@ -16,3 +16,4 @@ if not _ASTROPY_SETUP_:
     from . import nirspec
     from . import nircam 
     from . import miri
+    from . import reformat_nrs_ff

--- a/jwreftools/reformat_nrs_ff/__init__.py
+++ b/jwreftools/reformat_nrs_ff/__init__.py
@@ -1,0 +1,1 @@
+from .reformat_nrs_ff import process_files

--- a/jwreftools/reformat_nrs_ff/reformat_nrs_ff.py
+++ b/jwreftools/reformat_nrs_ff/reformat_nrs_ff.py
@@ -1,0 +1,762 @@
+import glob
+import os
+
+import numpy as np
+from astropy.io import fits
+
+__all__ = ['process_files']
+
+
+# An output file name will be constructed by appending the input file name
+# to a prefix; this is the default string.
+PREFIX = "v5_"
+
+# If there is no USEAFTER keyword in the primary header, a keyword will be
+# created with this value.
+NEW_USEAFTER = "2016-06-20T00:00:00"
+
+# Function reformat_one_file determines the exposure type and the
+# optical path part from strings in the input file name, as follows:
+#  exposure type:
+#    "FS"  --> "NRS_FIXEDSLIT"
+#    "IFU" --> "NRS_IFU"
+#    "MOS" --> "NRS_MSASPEC"
+#  optical path part:
+#    "fflat" --> fore optics part
+#    "sflat" --> spectrograph part
+#    "dflat" --> detector part
+
+# Possible values for optical_path_part.
+F_FLAT = "fflat"
+S_FLAT = "sflat"
+D_FLAT = "dflat"
+
+# Mapping from the slit names used by the IDT to the slit names used by DMS.
+dms_slit_names = {"SLIT_A_200_1": "S200A1",
+                  "SLIT_A_200_2": "S200A2",
+                  "SLIT_A_400": "S400A1",
+                  "SLIT_B_200": "S200B1",
+                  "SLIT_A_1600": "S1600A1"}
+
+# For S_FLAT files for FS and IFU, the FILTER keyword is "OPAQUE".  The
+# correct filter name can be determined from the FLAT[1-5] portion of the
+# file name (or from the REFTYPE keyword, e.g. CAAFLAT1).
+filter_names = {"FLAT1": "F100LP",
+                "FLAT2": "F170LP",
+                "FLAT3": "F290LP",
+                "FLAT4": "F070LP",
+                "FLAT5": "CLEAR"}
+
+
+def process_files(pattern, prefix=PREFIX, verbose=True):
+    """Convert all the FITS files in the specified directory.
+
+    Parameters
+    ----------
+    pattern: str
+        The path name (wildcards are permitted) to one or more NIRSpec
+        flat-field files.  These files will be copied and reformatted;
+        the input files themselves will not be modified.
+        See also `prefix`.
+
+    prefix: str, e.g. "v5_"
+        For each input file, the output file name will be constructed by
+        removing the directory (if any) and then concatenating to `prefix`.
+
+    verbose: bool
+        If True, print info.
+    """
+
+    files = glob.glob(pattern)
+    if len(files) > 1:
+        files.sort()
+    bad_files = ["nirspec_MOS_sflat_G140H_OPAQUE_FLAT4_nrs1_f_01.01.fits"]
+    for filename in files:
+        if os.path.basename(filename) in bad_files:
+            print("Warning:  skipping {}".format(filename), flush=True)
+            continue
+        reformat_one_file(filename, prefix, verbose)
+
+
+def reformat_one_file(filename, prefix=PREFIX, verbose=True):
+    """Convert the specified file.
+
+    Parameters
+    ----------
+    filename: str
+        The full name (i.e. including directory) of a NIRSpec flat-field
+        reference file, in the format used by the NIRSpec IDT.  The file
+        itself will not be modified; instead, a reformatted copy of the
+        file will be created, using the same name but with a prefix
+        prepended.  See also `prefix`.
+
+    prefix: str, e.g. "v5_"
+        The output file name will be the same as the input name, except
+        that the output name will be prefixed by this string, and the output
+        file will be written to the default directory (unless `prefix`
+        includes a directory name), rather than to the directory containing
+        the input file.
+
+    verbose: bool
+        If True, print info.
+    """
+
+    input = os.path.basename(filename)
+    output = prefix + input
+    if output == filename:
+        raise RuntimeError("Input and output file names may not be the same.")
+
+    if filename.find("_IFU") >= 0:
+        exposure_type = "NRS_IFU"
+    elif filename.find("_MOS") >= 0:
+        exposure_type = "NRS_MSASPEC"
+    elif filename.find("_FS") >= 0:
+        exposure_type = "NRS_FIXEDSLIT"
+    else:
+        exposure_type = "N/A"
+
+    filename_lc = filename.lower()
+    if filename_lc.find("fflat") >= 0:
+        optical_path_part = F_FLAT
+    elif filename_lc.find("sflat") >= 0:
+        optical_path_part = S_FLAT
+    elif filename_lc.find("dflat") >= 0:
+        optical_path_part = D_FLAT
+    else:
+        optical_path_part = None
+
+    if verbose:
+        print("filename = {}".format(filename), flush=True)
+        print("exposure type = {}".format(exposure_type))
+        print("optical path part = {}".format(optical_path_part))
+
+    ifd = fits.open(filename)
+    fix_primary_header(ifd, filename, NEW_USEAFTER, exposure_type,
+                       optical_path_part, verbose)
+    ofd = fits.HDUList(fits.PrimaryHDU(header=ifd[0].header))
+
+    rename_extensions(ifd, exposure_type, optical_path_part, verbose)
+
+    # sci, dq, err, etc. are lists of indices.
+    (sci, dq, err, slit, fast_var, dq_def) = scan_HDU_list(ifd, verbose)
+
+    copy_extensions_to_output(ifd, ofd, filename,
+                              exposure_type, optical_path_part,
+                              sci, dq, err, slit, fast_var, dq_def, verbose)
+
+    ofd.writeto(output)
+    ofd.close()
+    ifd.close()
+
+
+def fix_primary_header(ifd, filename, new_useafter, exposure_type,
+                       optical_path_part, verbose):
+    """Modify primary header keyword(s).
+
+    If keyword INSRTUME is found in the primary header, that keyword
+    will be renamed to INSTRUME.
+    Keyword USEAFTER will be assigned a value.
+    Keyword EXP_TYPE will be assigned a value.
+    Keyword REFTYPE will be assigned a value.
+    For S_FLAT files, if FILTER == "OPAQUE", a value will be assigned
+    based on the "FLAT[1-5]" portion of the file name.
+
+    Parameters
+    ----------
+    ifd: fits HDUList object
+        The input file handle.
+
+    filename: str
+        The name of the input file.  Portions of this string may be used
+        for populating the FILTER keyword.
+
+    new_useafter: str
+        This value will be used for populating USEAFTER.
+
+    exposure_type: str
+        The exposure type, e.g. "NRS_FIXEDSLIT".
+
+    optical_path_part: str
+        The component name:  "fflat", "sflat", or "dflat".
+
+    verbose: bool
+        If True, print info.
+    """
+
+    phdr = ifd[0].header
+    if "INSRTUME" in phdr:
+        phdr.rename_keyword("INSRTUME", "INSTRUME")
+        if verbose:
+            print("Keyword INSRTUME renamed to INSTRUME")
+
+    if "USEAFTER" in phdr:
+        old_useafter = phdr["useafter"]
+        words = old_useafter.split("T")
+        if (old_useafter.startswith("20") and len(old_useafter) == 19 and
+            len(words) == 2):
+            if verbose:
+                print("Keyword USEAFTER was OK:  {}".format(old_useafter))
+        else:
+            words = old_useafter.split("-")
+            if (old_useafter.startswith("20") and len(old_useafter) == 10 and
+                len(words) == 3):
+                    phdr["useafter"] = old_useafter + "T00:00:00"
+            else:
+                    phdr["useafter"] = new_useafter
+            if verbose:
+                print("Keyword USEAFTER changed from {} to {}"
+                      .format(old_useafter, phdr["useafter"]))
+    else:
+        phdr["useafter"] = new_useafter
+        if verbose:
+            print("New keyword USEAFTER = {} was added"
+                  .format(phdr["useafter"]))
+
+    if "EXP_TYPE" in phdr:
+        old_exp_type = phdr["exp_type"]
+        phdr["exp_type"] = exposure_type
+        if verbose:
+            print("Keyword EXP_TYPE changed from {} to {}"
+                  .format(old_exp_type, exposure_type))
+    else:
+        phdr["exp_type"] = exposure_type
+        if verbose:
+            print("New keyword EXP_TYPE = {} was added".format(exposure_type))
+
+    reftype = optical_path_part.upper()
+    if "REFTYPE" not in phdr:
+        phdr['reftype'] = reftype
+        if verbose:
+            print("Keyword REFTYPE = {} was added".format(reftype))
+    elif phdr['reftype'] != reftype:
+        if verbose:
+            print("Keyword REFTYPE changed from {} to {}"
+                  .format(phdr['reftype'], reftype))
+        phdr['reftype'] = reftype
+
+    if optical_path_part == S_FLAT:
+        filter = phdr['filter']
+        if filter == "OPAQUE":
+            words = filename.split("_")
+            foundit = False
+            for word in words:
+                if word.startswith("FLAT"):
+                    foundit = True
+                    flat_id = word
+                    break
+            if foundit:
+                new_filter = filter_names[flat_id]
+                phdr['filter'] = new_filter
+                print("Keyword FILTER changed from {} to {}"
+                      .format(filter, new_filter))
+            else:
+                print("Warning:  Can't populate FILTER keyword.")
+
+
+def rename_extensions(ifd, exposure_type, optical_path_part, verbose):
+    """Rename some extensions.
+
+    Parameters
+    ----------
+    ifd: fits HDUList object
+        The input file handle.
+
+    exposure_type: str
+        The exposure type, e.g. "NRS_FIXEDSLIT".
+
+    optical_path_part: str
+        The component name:  "fflat", "sflat", or "dflat".
+
+    verbose: bool
+        If True, print info.
+    """
+
+    n_hdu = len(ifd)
+
+    if exposure_type == "NRS_MSASPEC" and optical_path_part == F_FLAT:
+        # Change extname = SCI_Q<k> to extname = SCI, extver = <k>, etc.
+        # For each extension (i.e. not including the primary HDU) ...
+        for i in range(1, n_hdu):
+            ifd[i].header["extver"] = 1                 # default
+            if ifd[i].header["extname"].upper() == "DQ_DEF":
+                continue
+            for k in range(1, 5):
+                suffix = "Q{}".format(k)
+                extname = ifd[i].header["extname"].upper()
+                if extname.endswith(suffix):
+                    if extname.startswith("SCI"):
+                        ifd[i].header["extname"] = "SCI"
+                        ifd[i].header["extver"] = k
+                    elif extname.startswith("ERR"):
+                        ifd[i].header["extname"] = "ERR"
+                        ifd[i].header["extver"] = k
+                    elif extname.startswith("DQ"):
+                        ifd[i].header["extname"] = "DQ"
+                        ifd[i].header["extver"] = k
+                    elif extname.startswith("Q"):
+                        ifd[i].header["extname"] = "FAST_VARIATION"
+                        ifd[i].header["extver"] = k
+                    if verbose:
+                        print("{}:  {} --> {}, {}".format(i, extname,
+                            ifd[i].header["extname"], ifd[i].header["extver"]))
+
+    for i in range(1, n_hdu):
+        extname = ifd[i].header["extname"].upper()
+        if extname == "RQE" or extname == "IFU" or extname == "VECTOR":
+            ifd[i].header["extname"] = "FAST_VARIATION"
+            ifd[i].header["extver"] = 1
+            if verbose:
+                print("{} {} --> {} {}".format(i, extname,
+                    ifd[i].header["extname"], ifd[i].header["extver"]))
+        if ifd[i].header.get("extver", -999) == -999:
+            ifd[i].header["extver"] = 1
+
+
+def scan_HDU_list(ifd, verbose):
+    """Find various extensions in the input file.
+
+    Parameters
+    ----------
+    ifd: fits HDUList object
+        The input file handle.
+
+    verbose: bool
+        If True, print info.
+
+    Returns
+    -------
+    (sci, dq, err, slit, fast_var, dq_def): tuple of lists
+        sci: list
+            Indices of SCI extension(s) in the input file.
+        dq: list
+            Indices of DQ extension(s) in the input file.
+        err: list
+            Indices of ERR extension(s) in the input file.
+        slit: list
+            Indices of fast-variation extensions for fixed slits in the input
+            file.  It will not be the case that both `slit` and `fast_var`
+            are populated; both may be empty.
+        fast_var: list
+            Indices of fast-variation extension(s) in the input file.
+        dq_def: list
+            Index of the DQ_DEF extension in the input file.
+    """
+
+    n_hdu = len(ifd)
+
+    sci = []
+    dq = []
+    err = []
+    slit = []
+    fast_var = []
+    dq_def = []
+    for i in range(1, n_hdu):
+        extname = ifd[i].header.get("extname", "").lower()
+        if extname.startswith("sci"):
+            sci.append(i)
+        elif extname == ("dq_def"):
+            dq_def.append(i)
+        elif extname.startswith("dq"):
+            dq.append(i)
+        elif extname.startswith("err"):
+            err.append(i)
+        elif extname.startswith("slit"):
+            slit.append(i)
+        elif extname == ("fast_variation"):
+            fast_var.append(i)
+        else:
+            print("Note:  extension {} will be ignored, extname = {}"
+                  .format(i, extname))
+
+    if verbose:
+        print("sci = {}".format(sci))
+        print("dq = {}".format(dq))
+        print("err = {}".format(err))
+        print("slit = {}".format(slit))
+        print("fast_var = {}".format(fast_var))
+        print("dq_def = {}".format(dq_def), flush=True)
+
+    return (sci, dq, err, slit, fast_var, dq_def)
+
+
+def copy_extensions_to_output(ifd, ofd, filename,
+                              exposure_type, optical_path_part,
+                              sci, dq, err, slit, fast_var, dq_def, verbose):
+    """Copy all the extensions that we want to keep.
+
+    Parameters
+    ----------
+    ifd: fits HDUList object
+        The input file handle.
+
+    ofd: fits HDUList object
+        The output file handle.
+
+    filename: str
+        The name of the input file.  This will be used for determining
+        which detector was used, if there is no DETECTOR keyword.
+
+    exposure_type: str
+        The exposure type, e.g. "NRS_FIXEDSLIT".
+
+    optical_path_part: str
+        The component name:  "fflat", "sflat", or "dflat".
+
+    sci: list
+        Indices of SCI extension(s) in the input file.
+
+    dq: list
+        Indices of DQ extension(s) in the input file.
+
+    err: list
+        Indices of ERR extension(s) in the input file.
+
+    slit: list
+        Indices of fast-variation extensions for fixed slits in the input
+        file.  It should not be the case that both `slit` and `fast_var`
+        are populated; both may be empty.
+
+    fast_var: list
+        Indices of fast-variation extension(s) in the input file.
+
+    dq_def: list
+        Index of the DQ_DEF extension in the input file.
+
+    verbose: bool
+        If True, print info.
+    """
+
+    try:
+        detector = ifd[0].header['detector']
+    except KeyError:
+        print("Warning:  DETECTOR keyword not found; using the file name.")
+        filename_uc = filename.upper()
+        if filename_uc.find("_NRS1") >= 0:
+            detector = "NRS1"
+        elif filename_uc.find("_NRS2") >= 0:
+            detector = "NRS2"
+        else:
+            detector = "N/A"
+            if verbose and optical_path_part != F_FLAT:
+                print("Warning:  Could not determine which detector was used.")
+    if verbose:
+        print("detector = {}".format(detector), flush=True)
+
+    if exposure_type == "NRS_MSASPEC" and optical_path_part == F_FLAT:
+        shape = ifd[sci[0]].data.shape
+        # The DQ arrays in the input are all ones; replace with zeros.
+        dq_data = np.zeros(shape, dtype=np.uint32)
+        for k in range(4):
+            # Index of (SCI,k) extension.
+            i = sci[k]
+            imhdu = fits.ImageHDU(data=ifd[i].data.astype(np.float32),
+                                  header=ifd[i].header)
+            ofd.append(imhdu)
+            if len(ifd[i].data.shape) > 2:
+                wl_hdu = create_wavelength_table(ifd[i].header,
+                                                 ifd[i].data.shape[0], k + 1)
+            else:
+                wl_hdu = None
+            # Index of (DQ,k) extension.
+            i = dq[k]
+            imhdu = fits.ImageHDU(data=dq_data, header=ifd[i].header)
+            ofd.append(imhdu)
+            # Index of (ERR,k) extension.
+            i = err[k]
+            imhdu = fits.ImageHDU(data=ifd[i].data.astype(np.float32),
+                                  header=ifd[i].header)
+            ofd.append(imhdu)
+            if wl_hdu is not None:
+                ofd.append(wl_hdu)
+                wl_hdu = None
+            # Index of the fast-variation table extension.
+            i = fast_var[k]
+            fv_hdu = reformat_fast_var_table(ifd, [i], k + 1)
+            ofd.append(fv_hdu)
+    else:
+        wl_hdu = None                           # initial value
+        # Index of SCI extension.
+        if len(sci) > 0:
+            i = sci[0]
+            sci_data = ifd[i].data
+            ifd[i].data[...] = flip_sci(sci_data, detector).copy()
+            ofd.append(ifd[i])
+            del sci_data
+            if len(ifd[i].data.shape) > 2:
+                wl_hdu = create_wavelength_table(ifd[i].header,
+                                                 ifd[i].data.shape[0], 1)
+        # Index of DQ extension.
+        if len(dq) > 0:
+            i = dq[0]
+            dq_data = ifd[i].data.astype(np.uint32)
+            mod_data = flip_sci(dq_data, detector)
+            imhdu = fits.ImageHDU(data=mod_data, header=ifd[i].header)
+            del dq_data, mod_data
+            ofd.append(imhdu)
+        # Index of ERR extension.
+        if len(err) > 0:
+            i = err[0]
+            err_data = ifd[i].data
+            ifd[i].data[...] = flip_sci(err_data, detector).copy()
+            ofd.append(ifd[i])
+            del err_data
+        if wl_hdu is not None:
+            ofd.append(wl_hdu)
+            del wl_hdu
+        if len(slit) > 0:
+            fv_hdu = reformat_fast_var_table(ifd, slit, 1)
+            ofd.append(fv_hdu)
+        if len(fast_var) > 0:
+            fv_hdu = reformat_fast_var_table(ifd, fast_var, 1)
+            ofd.append(fv_hdu)
+
+    if len(dq_def) > 0:
+        i = dq_def[0]
+        new_dq_def = rename_dq_def_cols(ifd[i], verbose)
+        ofd.append(new_dq_def)
+
+
+def flip_sci(sci_data, detector):
+    """Transpose and (if NRS2) rotate 180 degrees.
+
+    Parameters
+    ----------
+    sci_data: numpy array
+        An input data array, e.g. SCI or DQ.
+
+    detector: str
+        The detector name, either "NRS1" or "NRS2".
+
+    Returns
+    -------
+    mod_data: numpy array
+        The same values as in `sci_data`, but transposed and possibly
+        rotated 180 degrees.
+    """
+
+    shape = sci_data.shape
+    naxis = len(shape)
+    if naxis < 2 or naxis > 3:
+        print("Warning:  SCI data have dimension {}".format(naxis), flush=True)
+        return sci_data
+
+    if detector.upper() == "NRS1":
+        if naxis == 2:
+            mod_data = np.swapaxes(sci_data, 0, 1)
+        elif naxis == 3:
+            mod_data = np.swapaxes(sci_data, 1, 2)
+    elif detector.upper() == "NRS2":
+        if naxis == 2:
+            mod_data = np.swapaxes(sci_data, 0, 1)[::-1, ::-1]
+        elif naxis == 3:
+            mod_data = np.swapaxes(sci_data, 1, 2)[:, ::-1, ::-1]
+
+    return mod_data
+
+
+def rename_dq_def_cols(input_dq_def, verbose):
+    """Rename column name VAL to VALUE; change string lengths.
+
+    Parameters
+    ----------
+    input_dq_def: fits HDU object
+        A dq_def table
+
+    verbose: bool
+        If True, print old and new column names.
+
+    Returns
+    -------
+    new_dq_def
+        A copy of input_dq_def, but with column VAL renamed to Value.
+    """
+
+    for name in input_dq_def.data.names:
+        if name.lower() == "value":
+            if verbose:
+                print("The input DQ_DEF table is OK as it is.")
+            return input_dq_def
+
+    if verbose:
+        print("Input DQ_DEF: {}".format(input_dq_def.data.names))
+    nrows = len(input_dq_def.data)
+    col = []
+    col.append(fits.Column(name="Bit", format="J"))
+    col.append(fits.Column(name="Value", format="J"))
+    col.append(fits.Column(name="Name", format="30A"))
+    col.append(fits.Column(name="Description", format="60A"))
+    # xxx col.append(fits.Column(name="BIT", format="J"))
+    # xxx col.append(fits.Column(name="VALUE", format="J"))
+    # xxx col.append(fits.Column(name="NAME", format="30A"))
+    # xxx col.append(fits.Column(name="DESCRIPTION", format="60A"))
+    cd = fits.ColDefs(col)
+    new_dq_def = fits.BinTableHDU.from_columns(cd, nrows=nrows)
+    new_dq_def.header["extname"] = "DQ_DEF"
+    new_dq_def.header["extver"] = 1
+    new_dq_def.data["BIT"][:] = input_dq_def.data["BIT"].copy()
+    new_dq_def.data["VALUE"][:] = input_dq_def.data["VAL"].copy()
+    new_dq_def.data["NAME"][:] = input_dq_def.data["NAME"].copy()
+    new_dq_def.data["DESCRIPTION"][:] = input_dq_def.data["DESCRIPTION"].copy()
+    if verbose:
+        print("New DQ_DEF:   {}".format(new_dq_def.data.names), flush=True)
+
+    return new_dq_def
+
+
+def create_wavelength_table(hdr, nrows_data, extver=1):
+    """Create a bintable HDU of wavelengths from header keywords.
+
+    Parameters
+    ----------
+    hdr: fits Header object
+        Header for a SCI extension.
+
+    nrows_data: int
+        Length of the first axis of the SCI data array.  This is the
+        number of wavelength values that we expect to read from header
+        keywords, and the number of rows that we will use when creating
+        the table of wavelengths.  It is an error if there are not at
+        least this many header keywords giving values of wavelength.
+
+    Returns
+    -------
+    wl_hdu: fits BinTableHDU object
+        A new HDU containing a table of wavelengths, copied from `hdr`.
+    """
+
+    k = hdr["flat*"]
+    if len(k) < 1:
+        k = hdr["pflat*"]
+    if len(k) < 1:
+        raise RuntimeError("Wavelength keywords not found.")
+
+    nrows = nrows_data
+    if len(k) != nrows_data:
+        print("Note:  Data shape implies nrows = {}, "
+              "but there are {} keywords for wavelength:"
+              .format(nrows_data, len(k)))
+        for key in k:
+            print("    {}".format(key))
+        if len(k) < nrows_data:
+            raise RuntimeError("There must be a wavelength keyword for every "
+                               "plane of the SCI data array.")
+        nrows = min(nrows_data, len(k))
+
+    wavelength = np.zeros(nrows, dtype=np.float32)
+    last_wl = -1.
+    in_order = True                             # initial value
+    for (i, key) in enumerate(k):
+        wavelength[i] = hdr[key]
+        if wavelength[i] <= last_wl:
+            in_order = False
+        last_wl = wavelength[i]
+    if not in_order:
+        print("Note:  wavelengths (from keywords) are not "
+              "in increasing order.", flush=True)
+
+    col = [fits.Column(name="wavelength", format="E", unit="micrometer",
+                       array=wavelength)]
+    cd = fits.ColDefs(col)
+    wl_hdu = fits.BinTableHDU.from_columns(cd)
+    wl_hdu.header["extname"] = "WAVELENGTH"
+    wl_hdu.header["extver"] = extver
+
+    return wl_hdu
+
+
+def reformat_fast_var_table(ifd, i_list, extver):
+    """
+
+    Parameters
+    ----------
+    ifd: fits HDUList object
+        The input file handle.
+
+    i_list: list of int
+        The elements are the extension numbers of the (one or more)
+        fast-variation tables.  If there are more than one, they will be
+        consolidated into one output table with one row for each input
+        fast-variation table.
+
+    extver: int
+        For MSA data, this identifies which of the four micro-shutter
+        arrays the flat-field data are used for.  For other data, this
+        will have the value 1.
+
+    Returns
+    -------
+    fv_hdu: fits BinTableHDU object
+        A new HDU containing a table of wavelengths and corresponding
+        flat-field values.  There will be a column with name "slit_name"
+        that can have value "ANY", or for fixed-slit data it will be the
+        slit name (converted from the EXTNAME of the input file to the
+        DMS slit name).
+    """
+
+    nrows = len(i_list)
+
+    max_nelem = 0
+    for i in i_list:
+        input_wl = ifd[i].data.field("wavelength")
+        max_nelem = max(max_nelem, len(input_wl))
+    if max_nelem == 0:
+        max_nelem = 1
+
+    if len(i_list) > 0:
+        i = i_list[0]
+        fixed_slit = ifd[i].header.get("extname", "missing").startswith("SLIT")
+    else:
+        fixed_slit = False
+
+    col = []
+    col.append(fits.Column(name="slit_name", format="15A"))
+    col.append(fits.Column(name="nelem", format="1J"))
+    col.append(fits.Column(name="wavelength", format="{}E".format(max_nelem),
+                           unit="micrometer"))
+    col.append(fits.Column(name="data", format="{}E".format(max_nelem)))
+    cd = fits.ColDefs(col)
+    fv_hdu = fits.BinTableHDU.from_columns(cd, nrows=nrows)
+    fv_hdu.header["extname"] = "FAST_VARIATION"
+    fv_hdu.header["extver"] = extver
+
+    row = 0
+    for i in i_list:
+        input_wl = ifd[i].data.field("wavelength")
+        try:
+            input_data = ifd[i].data.field("data")
+        except KeyError:
+            input_data = ifd[i].data.field("RQE")
+        if np.nanmax(input_wl) <= 0.:
+            print("Wavelength was {}, changed to 1.".format(input_wl[0]),
+                  flush=True)
+            input_wl[:] = 1.
+            if max_nelem > 1:
+                print("Warning:  but max_nelem = {}".format(max_nelem),
+                      flush=True)
+        if np.nanmax(input_data) <= 0.:
+            print("Flat was {}, changed to 1.".format(input_data[0]),
+                  flush=True)
+            input_data[:] = 1.
+            if max_nelem > 1:
+                print("Warning:  but max_nelem = {}".format(max_nelem),
+                      flush=True)
+
+        nelem = len(input_wl)
+        if fixed_slit:
+            fv_hdu.data.field("slit_name")[row] = \
+                dms_slit_names[ifd[i].header["extname"].upper()]
+        else:
+            fv_hdu.data.field("slit_name")[row] = "ANY"
+
+        fv_hdu.data.field("nelem")[row] = nelem
+        if max_nelem == 1:
+            fv_hdu.data.field("wavelength")[:] = input_wl.copy()
+            fv_hdu.data.field("data")[:] = input_data.copy()
+        elif nelem > 1:
+            fv_hdu.data.field("wavelength")[row, :nelem] = input_wl.copy()
+            fv_hdu.data.field("wavelength")[row, nelem:] = 999.
+            fv_hdu.data.field("data")[row, :nelem] = input_data.copy()
+            fv_hdu.data.field("data")[row, nelem:] = 1.
+        row += 1
+
+    return fv_hdu

--- a/jwreftools/reformat_nrs_ff/tests/test_reformat_nrs_ff.py
+++ b/jwreftools/reformat_nrs_ff/tests/test_reformat_nrs_ff.py
@@ -1,0 +1,191 @@
+"""
+Test for reformat_nrs_ff
+"""
+import os
+import pytest
+from tempfile import TemporaryDirectory
+
+import numpy as np
+
+from astropy.io import fits
+
+from .. import reformat_nrs_ff
+
+
+@pytest.fixture
+def data_file():
+    # Create a dummy SFLAT file for NRS_FIXEDSLIT data.
+    ifd = fits.HDUList(fits.PrimaryHDU())
+    ifd[0].header['telescop'] = 'JWST'
+    ifd[0].header['detector'] = 'NRS2'
+    ifd[0].header['insrtume'] = 'NIRSPEC'   # keyword intentionally misspelled
+    ifd[0].header['filter'] = 'OPAQUE'
+    ifd[0].header['detector'] = 'NRS2'
+    ifd[0].header['grating'] = 'G235H'
+    ifd[0].header['useafter'] = '2016-06-28'
+    ifd[0].header['reftype'] = 'CAAFLAT2'
+    ifd[0].header['descrip'] = 'Flat-field reference file for Fixed Slits'
+    ifd[0].header['pedigree'] = 'GROUND'
+
+    sci_data = np.arange(5 * 5, dtype=np.float32).reshape((5, 5)) + 2
+    err_data = np.arange(5 * 5, dtype=np.float32).reshape((5, 5)) + 1
+    dq_data = np.arange(5 * 5, dtype=np.float32).reshape((5, 5))
+    ifd.append(fits.ImageHDU(data=sci_data, name='SCI'))
+    ifd.append(fits.ImageHDU(data=err_data, name='ERR'))
+    ifd.append(fits.ImageHDU(data=dq_data, name='DQ'))
+    del sci_data, err_data, dq_data
+
+    # DQ_DEF
+    col = []
+    col.append(fits.Column(name='BIT', format='1J', array=[0, 1, 2]))
+    col.append(fits.Column(name='VAL', format='1J', array=[1, 2, 4]))
+    col.append(fits.Column(name='NAME', format='20A',
+                           array=['DO_NOT_USE',
+                                  'UNRELIABLE_FLAT',
+                                  'NO_FLAT_FIELD']))
+    col.append(fits.Column(name='DESCRIPTION', format='40A',
+                           array=['Bad pixel. Do not use.',
+                                  'Flat variance large',
+                                  'Flat field cannot be measured']))
+    dq_def = fits.BinTableHDU.from_columns(fits.ColDefs(col))
+    dq_def.header['extname'] = 'DQ_DEF'
+    ifd.append(dq_def)
+
+    # Fast-variation tables.
+    # This wavelength column will be used for all five tables.
+    wl_col = fits.Column(name='WAVELENGTH', unit='MICROMETER',
+                         format='1E',
+                         array=[1.66, 2.16332, 2.66665, 3.16997])
+    col = []
+    col.append(wl_col)
+    col.append(fits.Column(name='DATA', unit='UNITLESS',
+                           format='1E',
+                           array=[0.26492, 0.26492, 1.63155, 1.63155]))
+    slit = fits.BinTableHDU.from_columns(fits.ColDefs(col))
+    slit.header['extname'] = 'SLIT_A_200_1'
+    ifd.append(slit)
+    col = []
+    col.append(wl_col)
+    col.append(fits.Column(name='DATA', unit='UNITLESS',
+                           format='1E',
+                           array=[0.27124, 0.27124, 1.64399, 1.64399]))
+    slit = fits.BinTableHDU.from_columns(fits.ColDefs(col))
+    slit.header['extname'] = 'SLIT_A_200_2'
+    ifd.append(slit)
+    col = []
+    col.append(wl_col)
+    col.append(fits.Column(name='DATA', unit='UNITLESS',
+                           format='1E',
+                           array=[0.52911, 0.52911, 3.54949, 3.54949]))
+    slit = fits.BinTableHDU.from_columns(fits.ColDefs(col))
+    slit.header['extname'] = 'SLIT_A_400'
+    ifd.append(slit)
+    col = []
+    col.append(wl_col)
+    col.append(fits.Column(name='DATA', unit='UNITLESS',
+                           format='1E',
+                           array=[0.42394, 0.42394, 1.64300, 1.64300]))
+    slit = fits.BinTableHDU.from_columns(fits.ColDefs(col))
+    slit.header['extname'] = 'SLIT_B_200'
+    ifd.append(slit)
+    col = []
+    col.append(wl_col)
+    col.append(fits.Column(name='DATA', unit='UNITLESS',
+                           format='1E',
+                           array=[2.29804, 2.29804, 15.0267, 15.0267]))
+    slit = fits.BinTableHDU.from_columns(fits.ColDefs(col))
+    slit.header['extname'] = 'SLIT_A_1600'
+    ifd.append(slit)
+
+    """The exposure type (e.g. NRS_FIXEDSLIT) and optical path part
+       (FFLAT, SFLAT, or DFLAT) are inferred from the file name.
+       For SFLAT (only), if keyword FILTER is "OPAQUE", the relevant
+       filter name for science data will be determined from the
+       "FLATi" (i = 1..5) string in the file name.
+       nirspec_FS_sflat_G235H_OPAQUE_FLAT2_nrs2_f_01.01.fits
+    """
+
+    with TemporaryDirectory() as dirname:
+        file_path = os.path.join(
+                dirname,
+                "nirspec_FS_sflat_G235H_OPAQUE_FLAT2_nrs2_f_01.01.fits")
+        ifd.writeto(file_path)
+        ifd.close()
+        yield file_path
+
+
+def test_reformat_nrs_ff(data_file):
+    # This function reformats the IDT version to be JWST pipeline compatible.
+
+    words = os.path.split(data_file)
+    prefix = os.path.join(words[0], "xyz_")
+    output_file = prefix + words[1]
+
+    reformat_nrs_ff.process_files(data_file, prefix=prefix, verbose=False)
+
+    ofd = fits.open(output_file)
+    phdr = ofd[0].header
+    assert phdr['telescop'] == 'JWST'
+    assert phdr['detector'] == 'NRS2'
+    assert phdr['instrume'] == 'NIRSPEC'
+    assert phdr['useafter'] == '2016-06-28T00:00:00'
+    assert phdr['exp_type'] == 'NRS_FIXEDSLIT'
+    assert phdr['reftype'] == 'SFLAT'
+    assert phdr['filter'] == 'F170LP'
+
+    sci_ref = np.array([[26., 21., 16., 11., 6.],
+                        [25., 20., 15., 10., 5.],
+                        [24., 19., 14.,  9., 4.],
+                        [23., 18., 13.,  8., 3.],
+                        [22., 17., 12.,  7., 2.]], dtype=np.float32)
+    assert np.allclose(ofd[("sci", 1)].data, sci_ref, rtol=0., atol=1.e-6)
+    del sci_ref
+
+    dq_ref = np.array([[24, 19, 14, 9, 4],
+                       [23, 18, 13, 8, 3],
+                       [22, 17, 12, 7, 2],
+                       [21, 16, 11, 6, 1],
+                       [20, 15, 10, 5, 0]], dtype=np.int32)
+    assert np.all(np.equal(ofd[("dq", 1)].data, dq_ref))
+    del dq_ref
+
+    err_ref = np.array([[25., 20., 15., 10., 5.],
+                        [24., 19., 14., 9., 4.],
+                        [23., 18., 13., 8., 3.],
+                        [22., 17., 12., 7., 2.],
+                        [21., 16., 11., 6., 1.]], dtype=np.float32)
+    assert np.allclose(ofd[("err", 1)].data, err_ref, rtol=0., atol=1.e-6)
+    del err_ref
+
+    slit_name_ref = np.array(['S200A1', 'S200A2', 'S400A1', 'S200B1',
+                              'S1600A1'])
+    nelem_ref = np.array([4, 4, 4, 4, 4], dtype=np.int32)
+    wavelength_ref = np.array([[1.66, 2.16332, 2.66665, 3.16997],
+                               [1.66, 2.16332, 2.66665, 3.16997],
+                               [1.66, 2.16332, 2.66665, 3.16997],
+                               [1.66, 2.16332, 2.66665, 3.16997],
+                               [1.66, 2.16332, 2.66665, 3.16997]],
+                              dtype=np.float32)
+    data_ref = np.array([[ 0.26492, 0.26492, 1.63155, 1.63155],
+                         [ 0.27124, 0.27124, 1.64399, 1.64399],
+                         [ 0.52911, 0.52911, 3.54949, 3.54949],
+                         [ 0.42394, 0.42394, 1.643,   1.643  ],
+                         [ 2.29804, 2.29804, 15.0267, 15.0267 ]],
+                        dtype=np.float32)
+
+    fast_var = ofd[("fast_variation", 1)].data
+    slit_name = fast_var.field("slit_name")
+    nelem = fast_var.field("nelem")
+    wavelength = fast_var.field("wavelength")
+    data = fast_var.field("data")
+
+    for i in range(len(slit_name_ref)):
+        assert slit_name[i] == slit_name_ref[i]
+
+    assert np.all(np.equal(nelem, nelem_ref))
+
+    assert np.allclose(wavelength, wavelength_ref, rtol=0., atol=1.e-6)
+
+    assert np.allclose(data, data_ref, rtol=0., atol=1.e-6)
+
+    ofd.close()

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
+[tool:pytest]
 minversion = 2.2
 norecursedirs = build docs/_build
 doctest_plus = enabled


### PR DESCRIPTION
reformat_nrs_ff.py can be used to reformat flat-field reference files in the format provided by the NIRSpec IDT to the format expected by the JWST pipeline `flat_field` step.  See issue #34.